### PR TITLE
Removed check for clickerConfig, added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+__pycache__
+config.py.my

--- a/main.py
+++ b/main.py
@@ -1065,7 +1065,7 @@ class HamsterKombatAccount:
         if (
             AccountConfigData is None
             or AccountConfigData is False
-            or "clickerConfig" not in AccountConfigData
+#            or "clickerConfig" not in AccountConfigData
         ):
             log.error(f"[{self.account_name}] Unable to get account config data.")
             self.SendTelegramLog(


### PR DESCRIPTION
`clickerConfig` is no longer in the json object response for the [`https://api.hamsterkombatgame.io/clicker/config`](https://api.hamsterkombatgame.io/clicker/config) request.

The check has been commented out. Additionally a .gitignore file was added to remove noise when running under venv