### PR TITLE
Config as example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 __pycache__
-config.py.my
+config.py
+

--- a/README.MD
+++ b/README.MD
@@ -52,7 +52,7 @@ pip install requests colorlog
 
 3. Add your accounts
 
-- Copy the `config.example.py` file to `config.py`.
+- Copy the `config.py.example` file to `config.py`.
 
 - Locate your `Authorization Bearer token` and place it in the `config.py` file. [How to Obtain a Token and Set Up the Bot?](https://www.youtube.com/watch?v=cjWE7DmMFgw)
 - [Find your device's UserAgent](https://github.com/masterking32/MasterHamsterKombatBot/blob/main/useful_files/user-agents.md) and place it in the `config.py` file.

--- a/README.MD
+++ b/README.MD
@@ -52,6 +52,8 @@ pip install requests colorlog
 
 3. Add your accounts
 
+- Copy the `config.example.py` file to `config.py`.
+
 - Locate your `Authorization Bearer token` and place it in the `config.py` file. [How to Obtain a Token and Set Up the Bot?](https://www.youtube.com/watch?v=cjWE7DmMFgw)
 - [Find your device's UserAgent](https://github.com/masterking32/MasterHamsterKombatBot/blob/main/useful_files/user-agents.md) and place it in the `config.py` file.
 - Configure accounts

--- a/config.py.example
+++ b/config.py.example
@@ -40,6 +40,7 @@ AccountList = [
             "wait_for_best_card": True,  # Recommended to keep it True for high-level accounts
             "enable_parallel_upgrades": True,  # Enable parallel card upgrades. This will buy cards in parallel if the best card is on cooldown. It should speed up the profit.
             "parallel_upgrades_max_price_per_hour": 1000,  # Cards with less than X coins per 1k will be bought
+            "show_num_buy_options": 10,  # Number of buy options to show in the logs, ranked by best value
         },
         # If you have enabled Telegram bot logging,
         # you can add your chat ID below to receive logs in your Telegram account.

--- a/config.py.example
+++ b/config.py.example
@@ -40,7 +40,7 @@ AccountList = [
             "wait_for_best_card": True,  # Recommended to keep it True for high-level accounts
             "enable_parallel_upgrades": True,  # Enable parallel card upgrades. This will buy cards in parallel if the best card is on cooldown. It should speed up the profit.
             "parallel_upgrades_max_price_per_hour": 1000,  # Cards with less than X coins per 1k will be bought
-            "show_num_buy_options": 10,  # Number of buy options to show in the logs, ranked by best value
+            "show_num_buy_options": 10,  # Number of card buy options to show in the logs, ranked by best value, 0 disables this.
         },
         # If you have enabled Telegram bot logging,
         # you can add your chat ID below to receive logs in your Telegram account.

--- a/main.py
+++ b/main.py
@@ -1092,10 +1092,7 @@ class HamsterKombatAccount:
 
         log.info(f"[{self.account_name}] Getting account config data...")
         AccountConfigData = self.GetAccountConfigRequest()
-        if (
-            AccountConfigData is None
-            or AccountConfigData is False
-        ):
+        if AccountConfigData is None or AccountConfigData is False:
             log.error(f"[{self.account_name}] Unable to get account config data.")
             self.SendTelegramLog(
                 f"[{self.account_name}] Unable to get account config data.",
@@ -1345,6 +1342,12 @@ class HamsterKombatAccount:
             )
 
             balanceCoins -= current_selected_card["price"]
+
+            if balanceCoins <= self.config["auto_upgrade_min"]:
+                log.warning(
+                    f"[{self.account_name}] Upgrade purchase would decrease balance below minimum limit, aborting."
+                )
+                return
 
             log.info(f"[{self.account_name}] Attempting to buy an upgrade...")
             time.sleep(2)


### PR DESCRIPTION
Moved the `config.py` file to `config.py.example` so that users can update without having to redo config. Updated README.md to instruct the user to copy `config.py.example` to `config.py`

Added a config option to show the N best buy options available `show_num_buy_options`. A value of zero disables this.

Added explanation around the price coefficient / expense check.