### PR TITLE
Updated points generation for tiles

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -42,7 +42,8 @@ AccountList = [
             "parallel_upgrades_max_price_per_hour": 1000,  # Cards with less than X coins per 1k will be bought
             "show_num_buy_options": 0,  # Number of card buy options to show in the logs, ranked by best value, 0 disables this.
             "max_promo_games_per_round": 3,  # Maximum number of promo games to play in a single round, 0 disables this.
-            "mg_max_tiles_points_percent": 20, # Maximum value for using points in percentages for the mini game Tiles
+            "mg_max_tiles_points": 25, # Maximum points per seconds for spend point generation in random.randint(waitTime * 2, waitTime * mg_max_tiles_points)
+            # does not guarantee that you will receive the full amount possible per day
         },
         # If you have enabled Telegram bot logging,
         # you can add your chat ID below to receive logs in your Telegram account.

--- a/main.py
+++ b/main.py
@@ -867,7 +867,13 @@ class HamsterKombatAccount:
             responseGameData = response["dailyKeysMiniGames"]
             startDate = responseGameData["startDate"]
             remainPoints = responseGameData["remainPoints"]
-            maxMultiplier = min(self.GetConfig('mg_max_tiles_points_percent', 20), 100) / 100
+            maxMultiplier = max(2, self.GetConfig('mg_max_tiles_points', 25))
+            pointsToSpend = 0
+            if remainPoints > 300:
+                pointsToSpend = random.randint(waitTime * 2, waitTime * maxMultiplier)
+            else:
+                pointsToSpend = remainPoints
+            pointsToSpend = min(pointsToSpend, remainPoints)
             number = int(
                 datetime.datetime.fromisoformat(
                     startDate.replace("Z", "+00:00")
@@ -878,11 +884,7 @@ class HamsterKombatAccount:
             res = ""
             score_per_game = {
                 "Candles": 0,
-                "Tiles": (
-                    random.randint(int(remainPoints * 0.1), int(remainPoints * maxMultiplier))
-                    if remainPoints > 300
-                    else remainPoints
-                ),
+                "Tiles": pointsToSpend,
             }
 
             for i in range(1, number_len + 1):
@@ -929,7 +931,9 @@ class HamsterKombatAccount:
                 )
                 return
             log.info(
-                f"[{self.account_name}] Mini game {game['id']} claimed successfully, + {number_to_string(response['bonus'])} {'keys' if game['id'] == 'Candles' else 'coins'}"
+                f"[{self.account_name}] Mini game {game['id']} claimed successfully, + {number_to_string(response['bonus'])} "
+                f"{'keys' if game['id'] == 'Candles' else f'coins, spent {number_to_string(pointsToSpend)} points, '}"
+                f"{number_to_string(remainPoints - pointsToSpend)}/{number_to_string(responseGameData['maxPoints'])} remain."
             )
 
         log.info(f"[{self.account_name}] Mini game phase completed.")


### PR DESCRIPTION
Updated the generation of points for tiles to reduce one-time gains
Minimum value to generate based on maxPoints / totalSecondsToNextAttempt = 2 pts / sec
`This update does not guarantee that you can get the full amount possible per day at low mg_max_tiles_points, but it looks less suspicious to the server (I hope).`